### PR TITLE
Add multiple dimensions to output formats

### DIFF
--- a/R/ggsave.R
+++ b/R/ggsave.R
@@ -22,9 +22,15 @@
 #'   if the `device` argument is a vector (e.g., `filename = "myplot"` with
 #'   `device = c("png", "pdf")` will create `myplot.png` and `myplot.pdf`).
 #' @param plot Plot to save, defaults to the last plot displayed.
-#' @param device Device to use. Can be a character vector of multiple devices,
-#'   e.g., `c("png", "pdf", "svg")`.
-#' @param ... Other arguments passed on to [ggplot2::ggsave()].
+#' @param device Device to use. Can be either:
+#'   - A character vector of multiple devices, e.g., `c("png", "pdf", "svg")`.
+#'   - A list of format specifications with dimensions, e.g., 
+#'     `list(list(filetype = "png", width = 180, height = 120, units = "mm"),
+#'           list(filetype = "pdf", width = 90, height = 120, units = "mm"))`.
+#'   - A single device name as character.
+#' @param ... Other arguments passed on to [ggplot2::ggsave()]. Note that
+#'   width, height, and units specified in ... will be overridden by 
+#'   format-specific specifications when using the list format for device.
 #'
 #' @return Invisibly returns a vector of the saved file paths.
 #' @export
@@ -39,6 +45,17 @@
 #' # Creates plot.png and plot.pdf in a temporary directory
 #' f <- tempfile(pattern = "plot")
 #' ggsave(filename = f, plot = p, device = c("png", "pdf"))
+#'
+#' # --- Example 1b: Save with multiple dimensions ---
+#' # Creates plot_180x120.png, plot_90x120.png, plot_180x120.pdf, etc.
+#' f2 <- tempfile(pattern = "plot")
+#' figure_formats <- list(
+#'   list(filetype = "png", width = 180, height = 120, units = "mm"),
+#'   list(filetype = "png", width = 90, height = 120, units = "mm"),
+#'   list(filetype = "pdf", width = 180, height = 120, units = "mm"),
+#'   list(filetype = "jpg", width = 90, height = 120, units = "mm")
+#' )
+#' ggsave(filename = f2, plot = p, device = figure_formats)
 #'
 #' # --- Example 2: Avoid overwriting ---
 #' options(ggsaveR.overwrite_action = "unique")
@@ -110,27 +127,25 @@ ggsave <- function(filename, plot = last_plot(), device = NULL, ...) {
     ggsave_args$author <- creator
   }
 
-  # --- 2. Handle multiple devices ---
-  # If device is not specified, infer from filename extension
-  if (is.null(device)) {
-    device <- tolower(tools::file_ext(filename))
-    if (device == "") {
-      stop("Cannot determine device from filename with no extension.", call. = FALSE)
-    }
-  }
+  # --- 2. Handle multiple devices and formats ---
+  # Parse device specification (vector, list, or single device)
+  format_specs <- parse_device_specification(device, filename)
+  
+  saved_files <- character(length(format_specs))
 
-  devices <- device
-
-  # Base filename without extension
-  base_filename <- tools::file_path_sans_ext(filename)
-
-  saved_files <- character(length(devices))
-
-  for (i in seq_along(devices)) {
-    dev <- devices[i]
-
-    # Construct the full filename for this device
-    current_filename <- paste0(base_filename, ".", dev)
+  for (i in seq_along(format_specs)) {
+    spec <- format_specs[[i]]
+    dev <- spec$device
+    current_filename <- spec$filename
+    
+    # Prepare arguments specific to this format specification
+    current_args <- ggsave_args
+    
+    # Override with format-specific dimensions if provided
+    if (!is.null(spec$width)) current_args$width <- spec$width
+    if (!is.null(spec$height)) current_args$height <- spec$height
+    if (!is.null(spec$units)) current_args$units <- spec$units
+    if (!is.null(spec$dpi)) current_args$dpi <- spec$dpi
 
     # --- 3. Handle file overwriting ---
     if (file.exists(current_filename)) {
@@ -151,14 +166,14 @@ ggsave <- function(filename, plot = last_plot(), device = NULL, ...) {
         save_png_with_data,
         c(list(filename = current_filename, plot = plot,
                plot_call_str = plot_call_str, creator = creator),
-          ggsave_args)
+          current_args)
       )
     } else {
       # Use the original ggsave for all other cases
       do.call(
         ggplot2::ggsave,
         c(list(filename = current_filename, plot = plot, device = dev),
-          ggsave_args)
+          current_args)
       )
     }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -90,3 +90,116 @@ save_png_with_data <- function(filename, plot, plot_call_str = NULL, creator = N
 
   invisible(filename)
 }
+
+
+#' Parse device specification for multiple formats and dimensions
+#'
+#' This function handles both the legacy vector format (c("png", "pdf")) and 
+#' the new list format with dimensions.
+#'
+#' @param device Either a character vector of devices or a list of format specifications
+#' @param filename The base filename to use
+#' @return A list of format specifications, each containing device, filename, and dimension info
+#' @noRd
+parse_device_specification <- function(device, filename) {
+  
+  # If device is not specified, infer from filename extension
+  if (is.null(device)) {
+    device <- tolower(tools::file_ext(filename))
+    if (device == "") {
+      stop("Cannot determine device from filename with no extension.", call. = FALSE)
+    }
+  }
+  
+  # Base filename without extension
+  base_filename <- tools::file_path_sans_ext(filename)
+  
+  # Case 1: List format (new nested format)
+  if (is.list(device) && !is.character(device)) {
+    format_specs <- list()
+    
+    for (i in seq_along(device)) {
+      spec <- device[[i]]
+      
+      # Validate required fields
+      if (is.null(spec$filetype)) {
+        stop("Format specification ", i, " is missing 'filetype' field.", call. = FALSE)
+      }
+      
+      # Validate supported file formats
+      supported_formats <- c("png", "pdf", "svg", "ps", "eps", "jpg", "jpeg", "tiff", "tif", "bmp")
+      if (!tolower(spec$filetype) %in% supported_formats) {
+        stop("Unsupported file format: ", spec$filetype, ". Supported formats: ", 
+             paste(supported_formats, collapse = ", "), call. = FALSE)
+      }
+      
+      # Generate filename with dimensions if specified
+      dimension_suffix <- ""
+      if (!is.null(spec$width) && !is.null(spec$height)) {
+        dimension_suffix <- paste0("_", spec$width, "x", spec$height)
+        if (!is.null(spec$units)) {
+          dimension_suffix <- paste0(dimension_suffix, spec$units)
+        }
+      }
+      
+      current_filename <- paste0(base_filename, dimension_suffix, ".", tolower(spec$filetype))
+      
+      # Map jpeg to jpg for device name (ggplot2 uses "jpeg" device name)
+      device_name <- if (tolower(spec$filetype) %in% c("jpg", "jpeg")) "jpeg" else tolower(spec$filetype)
+      # Map tif to tiff for device name  
+      device_name <- if (tolower(spec$filetype) == "tif") "tiff" else device_name
+      
+      format_specs[[i]] <- list(
+        device = device_name,
+        filename = current_filename,
+        width = spec$width,
+        height = spec$height,
+        units = spec$units,
+        dpi = spec$dpi
+      )
+    }
+    
+    return(format_specs)
+  }
+  
+  # Case 2: Character vector format (legacy support)
+  if (is.character(device)) {
+    devices <- device
+    format_specs <- list()
+    
+    for (i in seq_along(devices)) {
+      dev <- devices[i]
+      
+      # Validate supported file formats for legacy format too
+      supported_formats <- c("png", "pdf", "svg", "ps", "eps", "jpg", "jpeg", "tiff", "tif", "bmp")
+      if (!tolower(dev) %in% supported_formats) {
+        stop("Unsupported file format: ", dev, ". Supported formats: ", 
+             paste(supported_formats, collapse = ", "), call. = FALSE)
+      }
+      
+      current_filename <- paste0(base_filename, ".", dev)
+      
+      # Map file extensions to ggplot2 device names
+      device_name <- if (tolower(dev) %in% c("jpg", "jpeg")) "jpeg" else tolower(dev)
+      device_name <- if (tolower(dev) == "tif") "tiff" else device_name
+      
+      format_specs[[i]] <- list(
+        device = device_name,
+        filename = current_filename,
+        width = NULL,
+        height = NULL,
+        units = NULL,
+        dpi = NULL
+      )
+    }
+    
+    return(format_specs)
+  }
+  
+  # Case 3: Single device (convert to vector format)
+  if (length(device) == 1) {
+    return(parse_device_specification(as.character(device), filename))
+  }
+  
+  stop("Invalid device specification. Must be a character vector or a list of format specifications.", call. = FALSE)
+}

--- a/tests/testthat/test-test-multiple-formats.R
+++ b/tests/testthat/test-test-multiple-formats.R
@@ -1,4 +1,4 @@
-test_that("ggsave can save to multiple formats at once", {
+test_that("ggsave can save to multiple formats at once (legacy vector format)", {
   withr::local_dir(tempdir())
 
   base_filename <- "multi_format_plot"
@@ -15,4 +15,198 @@ test_that("ggsave can save to multiple formats at once", {
 
   # Check that the function returns the paths of the created files
   expect_equal(sort(saved_files), sort(c(expected_png, expected_pdf)))
+})
+
+test_that("ggsave can save with multiple dimensions using list format", {
+  withr::local_dir(tempdir())
+  
+  base_filename <- "multi_dimension_plot"
+  
+  # Define multiple format specifications with different dimensions
+  format_specs <- list(
+    list(filetype = "png", width = 180, height = 120, units = "mm"),
+    list(filetype = "png", width = 90, height = 120, units = "mm"),
+    list(filetype = "pdf", width = 180, height = 120, units = "mm")
+  )
+  
+  # Save using the new list format
+  saved_files <- ggsave(base_filename, p, device = format_specs)
+  
+  # Check that all files were created with appropriate dimension suffixes
+  expected_files <- c(
+    "multi_dimension_plot_180x120mm.png",
+    "multi_dimension_plot_90x120mm.png", 
+    "multi_dimension_plot_180x120mm.pdf"
+  )
+  
+  for (file in expected_files) {
+    expect_true(file.exists(file), info = paste("File should exist:", file))
+  }
+  
+  # Check return values
+  expect_equal(sort(saved_files), sort(expected_files))
+})
+
+test_that("ggsave supports new file formats (jpg, eps, tiff)", {
+  withr::local_dir(tempdir())
+  
+  base_filename <- "new_formats_test"
+  
+  # Test new file formats
+  format_specs <- list(
+    list(filetype = "jpg", width = 100, height = 80, units = "mm"),
+    list(filetype = "eps", width = 100, height = 80, units = "mm"),
+    list(filetype = "tiff", width = 100, height = 80, units = "mm")
+  )
+  
+  saved_files <- ggsave(base_filename, p, device = format_specs)
+  
+  expected_files <- c(
+    "new_formats_test_100x80mm.jpg",
+    "new_formats_test_100x80mm.eps",
+    "new_formats_test_100x80mm.tiff"
+  )
+  
+  for (file in expected_files) {
+    expect_true(file.exists(file), info = paste("File should exist:", file))
+  }
+  
+  expect_equal(sort(saved_files), sort(expected_files))
+})
+
+test_that("ggsave handles mixed legacy and new format specifications", {
+  withr::local_dir(tempdir())
+  
+  base_filename <- "mixed_test"
+  
+  # Test legacy vector format still works
+  saved_files_legacy <- ggsave(paste0(base_filename, "_legacy"), p, device = c("png", "pdf"))
+  expect_length(saved_files_legacy, 2)
+  
+  # Test new list format  
+  format_specs <- list(
+    list(filetype = "png", width = 50, height = 50, units = "mm")
+  )
+  saved_files_new <- ggsave(paste0(base_filename, "_new"), p, device = format_specs)
+  expect_length(saved_files_new, 1)
+  expect_true(file.exists("mixed_test_new_50x50mm.png"))
+})
+
+test_that("ggsave generates appropriate filenames for different dimension combinations", {
+  withr::local_dir(tempdir())
+  
+  base_filename <- "filename_test"
+  
+  # Test various dimension combinations
+  format_specs <- list(
+    list(filetype = "png", width = 100, height = 200),  # no units
+    list(filetype = "pdf", width = 150, height = 300, units = "mm"), # with units
+    list(filetype = "jpg")  # no dimensions
+  )
+  
+  saved_files <- ggsave(base_filename, p, device = format_specs)
+  
+  expected_files <- c(
+    "filename_test_100x200.png",     # dimensions without units
+    "filename_test_150x300mm.pdf",   # dimensions with units  
+    "filename_test.jpg"              # no dimensions
+  )
+  
+  expect_equal(sort(saved_files), sort(expected_files))
+  
+  for (file in expected_files) {
+    expect_true(file.exists(file), info = paste("File should exist:", file))
+  }
+})
+
+test_that("ggsave format specifications override global width/height arguments", {
+  withr::local_dir(tempdir())
+  
+  base_filename <- "override_test"
+  
+  format_specs <- list(
+    list(filetype = "png", width = 50, height = 60, units = "mm")
+  )
+  
+  # Pass global width/height that should be overridden
+  saved_files <- ggsave(base_filename, p, device = format_specs, 
+                       width = 999, height = 999, units = "in")
+  
+  # The file should use the format-specific dimensions (50x60mm), not global (999x999in)
+  expect_true(file.exists("override_test_50x60mm.png"))
+  
+  # Read the image and verify dimensions (approximate check)
+  # 50mm at 72 dpi ≈ 142 pixels, 60mm ≈ 170 pixels
+  img <- png::readPNG("override_test_50x60mm.png")
+  # We'll just check that it's not the massive size that would result from 999 inches
+  expect_lt(dim(img)[2], 1000)  # width should be reasonable
+  expect_lt(dim(img)[1], 1000)  # height should be reasonable
+})
+
+test_that("ggsave throws appropriate errors for invalid format specifications", {
+  withr::local_dir(tempdir())
+  
+  # Test missing filetype
+  expect_error(
+    ggsave("test", p, device = list(list(width = 100, height = 100))),
+    "missing 'filetype' field"
+  )
+  
+  # Test unsupported format
+  expect_error(
+    ggsave("test", p, device = list(list(filetype = "invalid_format"))),
+    "Unsupported file format"
+  )
+  
+  # Test unsupported format in legacy vector format
+  expect_error(
+    ggsave("test", p, device = c("invalid_format")),
+    "Unsupported file format"
+  )
+})
+
+test_that("ggsave supports jpeg file extensions and aliases", {
+  withr::local_dir(tempdir())
+  
+  base_filename <- "jpeg_test"
+  
+  # Test both jpg and jpeg extensions
+  format_specs <- list(
+    list(filetype = "jpg", width = 100, height = 100, units = "mm"),
+    list(filetype = "jpeg", width = 100, height = 100, units = "mm")
+  )
+  
+  saved_files <- ggsave(base_filename, p, device = format_specs)
+  
+  expected_files <- c(
+    "jpeg_test_100x100mm.jpg",
+    "jpeg_test_100x100mm.jpeg"
+  )
+  
+  for (file in expected_files) {
+    expect_true(file.exists(file), info = paste("File should exist:", file))
+  }
+})
+
+test_that("ggsave supports tiff file extensions and aliases", {
+  withr::local_dir(tempdir())
+  
+  base_filename <- "tiff_test"
+  
+  # Test both tif and tiff extensions
+  format_specs <- list(
+    list(filetype = "tif", width = 100, height = 100, units = "mm"),
+    list(filetype = "tiff", width = 100, height = 100, units = "mm")
+  )
+  
+  saved_files <- ggsave(base_filename, p, device = format_specs)
+  
+  expected_files <- c(
+    "tiff_test_100x100mm.tif",
+    "tiff_test_100x100mm.tiff"
+  )
+  
+  for (file in expected_files) {
+    expect_true(file.exists(file), info = paste("File should exist:", file))
+  }
 })


### PR DESCRIPTION
Enhance `ggsave` to support multiple output formats with per-format dimensions and new file types (JPG, EPS, TIFF).

---
<a href="https://cursor.com/background-agent?bcId=bc-52927bf6-4688-4a41-88f0-39f4ab889bae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-52927bf6-4688-4a41-88f0-39f4ab889bae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

